### PR TITLE
Allow use of multiple areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Options:
 
 area <AREA>           Portion of the page to analyze (top,left,bottom,right).
                        Example: "269.875,12.75,790.5,561". Default is entire page.
+                       If there are multiple areas to analyze:
+                       Example: ["269.875,12.75,790.5,561", "132.45,23.2,256.3,534"]
 
 columns <COLUMNS>     X coordinates of column boundaries. Example 
                       "10.1,20.2,30.3"

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -17,7 +17,13 @@ TabulaCommand.prototype.run = function () {
 
 TabulaCommand.prototype._build = function (pdfPath, commandArgs) {
   this.args = ['-jar', path.join(__dirname, 'tabula-java.jar')];
-  this.args = this.args.concat(_.toPairs(_.mapKeys(commandArgs, (value, key) => `--${_.kebabCase(key)}`)));
+  if (commandArgs["area"].constructor === Array){
+    var array = commandArgs["area"].map((item)=>{
+      this.args.push(['-a', item]);
+    });
+  }else{
+    this.args = this.args.concat(_.toPairs(_.mapKeys(commandArgs, (value, key) => `--${_.kebabCase(key)}`)));
+  }
   this.args = this.args.concat([pdfPath]);
   this.args = _.flatten(this.args);
   return this;


### PR DESCRIPTION
Allow the use of multiple areas by upgrading tabula's lib and adding some changes on cmd.js.
Now it is possible to use an array of areas as an option for Tabula.
Example:

```
var options = {
      area: ["191.85,11.03,245.46,835.21","171.879375,65.703125,184.494375,98.29"]
    };
```