### PR TITLE
fix for error when area is not in options

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -17,7 +17,7 @@ TabulaCommand.prototype.run = function () {
 
 TabulaCommand.prototype._build = function (pdfPath, commandArgs) {
   this.args = ['-jar', path.join(__dirname, 'tabula-java.jar')];
-  if (commandArgs["area"].constructor === Array){
+  if (commandArgs["area"] && commandArgs["area"].constructor === Array){
     var array = commandArgs["area"].map((item)=>{
       this.args.push(['-a', item]);
     });


### PR DESCRIPTION
After #3 if area is not in options exception is thrown:
`TypeError: Cannot read property 'constructor' of undefined`